### PR TITLE
Simplify the way to update table

### DIFF
--- a/models/kin.py
+++ b/models/kin.py
@@ -63,7 +63,10 @@ class KernelizedInstanceNorm(nn.Module):
             assert x_anchor != None
 
             if self.collection_mode:
-                x_std, x_mean = torch.std_mean(x, dim=(2, 3))
+                x_std, x_mean = torch.std_mean(x, dim=(2, 3))  # [B, C]
+                # x_anchor, y_anchor = [B], [B]
+                # table = [H, W, C]
+                # update std and mean to corresponing coordinates
                 self.mean_table[y_anchor, x_anchor] = x_mean
                 self.std_table[y_anchor, x_anchor] = x_std
 


### PR DESCRIPTION
After reviewing `forward()` and `collection()`, I think the shape of `y_anchor` and `x_anchor` is [B] which B means batch size. Pytorch fancy indexing can be used to batch update tensor's inner values like numpy.

Assume we have the following tensors with their shape:

```
X = [B]
Y = [B]
V = [B, C]
table = [H, W, C]
```

We can update values in `V` to the `table` with corresponding coordinates `X, Y`:

```python
table[Y, X] = V
```

The above code is equal to:

```python
for x, y, v in zip(X, Y, V):
    table[y, x] = v
```

After modification, `keepdim` in `torch.std_mean` is unnecessary and can be removed.
