### PR TITLE
Rename out_channels to num_features

### DIFF
--- a/F-LSeSim/models/kin.py
+++ b/F-LSeSim/models/kin.py
@@ -1,11 +1,12 @@
-import numpy as np
 import torch
 import torch.nn as nn
-from .util import get_kernel
+
+from utils.util import get_kernel
 
 
 class KernelizedInstanceNorm(nn.Module):
-    def __init__(self, out_channels=None, affine=True, device="cuda"):
+
+    def __init__(self, num_features, eps=0, affine=True, device="cuda"):
         super(KernelizedInstanceNorm, self).__init__()
 
         # if use normal instance normalization during evaluation mode
@@ -15,37 +16,43 @@ class KernelizedInstanceNorm(nn.Module):
         # during evaluation mode'
         self.collection_mode = False
 
-        self.out_channels = out_channels
+        self.num_features = num_features
+        self.eps = eps
         self.device = device
+
         if affine:
             self.weight = nn.Parameter(
-                torch.ones(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)
             self.bias = nn.Parameter(
-                torch.zeros(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.zeros(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)
 
     def init_collection(self, y_anchor_num, x_anchor_num):
+        # TODO: y_anchor_num => grid_height, x_anchor_num => grid_width
         self.y_anchor_num = y_anchor_num
         self.x_anchor_num = x_anchor_num
         self.mean_table = torch.zeros(
-            y_anchor_num, x_anchor_num, self.out_channels
+            y_anchor_num, x_anchor_num, self.num_features
         ).to(
             self.device
         )
         self.std_table = torch.zeros(
-            y_anchor_num, x_anchor_num, self.out_channels
+            y_anchor_num, x_anchor_num, self.num_features
         ).to(
             self.device
         )
 
     def init_kernel(self, kernel_padding, kernel_mode):
+        # TODO: 1. Consider to use strategy pattern
+        # TODO: 2. padding => kernel_size, and raise an error for even number
         kernel = get_kernel(padding=kernel_padding, mode=kernel_mode)
         self.kernel = kernel.to(self.device)
 
     def pad_table(self, padding):
         # modify
         # padded table shape inconsisency
+        # TODO: Don't permute the dimensions
         pad_func = nn.ReplicationPad2d((padding, padding, padding, padding))
         self.padded_mean_table = pad_func(
             self.mean_table.permute(2, 0, 1).unsqueeze(0)
@@ -55,11 +62,13 @@ class KernelizedInstanceNorm(nn.Module):
         )  # [H, W, C] -> [C, H, W] -> [N, C, H, W]
 
     def forward_normal(self, x):
-        x_std, x_mean = torch.std_mean(x, dim=(2, 3), keepdim=True)
+        x_var, x_mean = torch.var_mean(x, dim=(2, 3), keepdim=True)
+        x_std = torch.sqrt(x_var + self.eps)
         x = (x - x_mean) / x_std  # * self.weight + self.bias
         return x
 
     def forward(self, x, y_anchor=None, x_anchor=None, padding=1):
+        # TODO: Do not reply on self.training
         if self.training or self.normal_instance_normalization:
             return self.forward_normal(x)
 
@@ -68,7 +77,8 @@ class KernelizedInstanceNorm(nn.Module):
             assert x_anchor is not None
 
             if self.collection_mode:
-                x_std, x_mean = torch.std_mean(x, dim=(2, 3))  # [B, C]
+                x_var, x_mean = torch.var_mean(x, dim=(2, 3))  # [B, C]
+                x_std = torch.sqrt(x_var + self.eps)
                 # x_anchor, y_anchor = [B], [B]
                 # table = [H, W, C]
                 # update std and mean to corresponing coordinates
@@ -133,80 +143,3 @@ def use_kernelized_instance_norm(model, padding=1):
             layer.pad_table(padding=padding)
             layer.collection_mode = False
             layer.normal_instance_normalization = False
-
-
-"""
-USAGE
-    support a dataset with a dataloader would return
-    (x, y_anchor, x_anchor) each time
-    kin = KernelizedInstanceNorm()
-    [TRAIN] anchors are not used during training
-    kin.train()
-    for (x, _, _) in dataloader:
-        kin(x)
-    [COLLECT] anchors are required and any batch size is allowed
-    kin.eval()
-    init_kernelized_instance_norm(
-        kin, y_anchor_num=$y_anchor_num,
-        x_anchor_num=$x_anchor_num,
-        kernel_padding=$kernel_padding,
-        kernel_mode=$kernel_mode,
-    )
-    for (x, y_anchor, x_anchor) in dataloader:
-        kin(x, y_anchor=y_anchor, x_anchor=x_anchor)
-    [INFERENCE] anchors are required and batch size is limited to 1 !!
-    kin.eval()
-    use_kernelized_instance_norm(kin, kernel_padding=$kernel_padding)
-    for (x, y_anchor, x_anchor) in dataloader:
-        kin(x, y_anchor=y_anchor, x_anchor=x_anchor, padding=$padding)
-    [INFERENCE WITH NORMAL INSTANCE NORMALIZATION] anchors are not required
-    kin.eval()
-    not_use_kernelized_instance_norm(kin)
-    for (x, _, _) in dataloader:
-        kin(x)
-"""
-
-if __name__ == "__main__":
-    import itertools
-
-    from torch.utils.data import DataLoader, Dataset
-
-    class TestDataset(Dataset):
-        def __init__(self, y_anchor_num=10, x_anchor_num=10):
-            self.y_anchor_num = y_anchor_num
-            self.x_anchor_num = x_anchor_num
-            self.anchors = list(
-                itertools.product(
-                    np.arange(0, y_anchor_num), np.arange(0, x_anchor_num)
-                )
-            )
-
-        def __len__(self):
-            return len(self.anchors)
-
-        def __getitem__(self, idx):
-            x = torch.randn(3, 512, 512)
-            y_anchor, x_anchor = self.anchors[idx]
-            return (x, y_anchor, x_anchor)
-
-    test_dataset = TestDataset()
-    test_dataloader = DataLoader(test_dataset, batch_size=5)
-
-    kin = KernelizedInstanceNorm(out_channels=3, device="cpu")
-    kin.eval()
-    init_kernelized_instance_norm(
-        kin,
-        y_anchor_num=10,
-        x_anchor_num=10,
-        kernel_padding=1,
-        kernel_mode="constant",
-    )
-
-    for (x, y_anchor, x_anchor) in test_dataloader:
-        kin(x, y_anchor=y_anchor, x_anchor=x_anchor)
-
-    use_kernelized_instance_norm(kin, kernel_padding=1)
-    test_dataloader = DataLoader(test_dataset, batch_size=1)
-    for (x, y_anchor, x_anchor) in test_dataloader:
-        x = kin(x, y_anchor=y_anchor, x_anchor=x_anchor, padding=1)
-        print(x.shape)

--- a/F-LSeSim/models/normalization.py
+++ b/F-LSeSim/models/normalization.py
@@ -4,12 +4,12 @@ from models.kin import KernelizedInstanceNorm
 from models.tin import ThumbInstanceNorm
 
 
-def get_normalization_layer(out_channels, normalization="kin"):
+def get_normalization_layer(num_features, normalization="kin"):
     if normalization == "kin":
-        return KernelizedInstanceNorm(out_channels=out_channels)
+        return KernelizedInstanceNorm(num_features=num_features)
     elif normalization == "tin":
-        return ThumbInstanceNorm(out_channels=out_channels)
+        return ThumbInstanceNorm(num_features=num_features)
     elif normalization == "in":
-        return nn.InstanceNorm2d(out_channels)
+        return nn.InstanceNorm2d(num_features)
     else:
         raise NotImplementedError

--- a/F-LSeSim/models/tin.py
+++ b/F-LSeSim/models/tin.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 class ThumbInstanceNorm(nn.Module):
-    def __init__(self, out_channels=None, affine=True):
+    def __init__(self, num_features, affine=True):
         super(ThumbInstanceNorm, self).__init__()
         self.thumb_mean = None
         self.thumb_std = None
@@ -11,10 +11,10 @@ class ThumbInstanceNorm(nn.Module):
         self.collection_mode = False
         if affine == True:
             self.weight = nn.Parameter(
-                torch.ones(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             )
             self.bias = nn.Parameter(
-                torch.zeros(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.zeros(size=(1, num_features, 1, 1), requires_grad=True)
             )
 
     def calc_mean_std(self, feat, eps=1e-5):

--- a/models/kin.py
+++ b/models/kin.py
@@ -5,8 +5,8 @@ from utils.util import get_kernel
 
 
 class KernelizedInstanceNorm(nn.Module):
-    # TODO: Can out_channels be None ?
-    def __init__(self, out_channels=None, eps=0, affine=True, device="cuda"):
+
+    def __init__(self, num_features, eps=0, affine=True, device="cuda"):
         super(KernelizedInstanceNorm, self).__init__()
 
         # if use normal instance normalization during evaluation mode
@@ -16,16 +16,16 @@ class KernelizedInstanceNorm(nn.Module):
         # during evaluation mode'
         self.collection_mode = False
 
-        self.out_channels = out_channels
+        self.num_features = num_features
         self.eps = eps
         self.device = device
 
         if affine:
             self.weight = nn.Parameter(
-                torch.ones(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)
             self.bias = nn.Parameter(
-                torch.zeros(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.zeros(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)
 
     def init_collection(self, y_anchor_num, x_anchor_num):
@@ -33,12 +33,12 @@ class KernelizedInstanceNorm(nn.Module):
         self.y_anchor_num = y_anchor_num
         self.x_anchor_num = x_anchor_num
         self.mean_table = torch.zeros(
-            y_anchor_num, x_anchor_num, self.out_channels
+            y_anchor_num, x_anchor_num, self.num_features
         ).to(
             self.device
         )
         self.std_table = torch.zeros(
-            y_anchor_num, x_anchor_num, self.out_channels
+            y_anchor_num, x_anchor_num, self.num_features
         ).to(
             self.device
         )

--- a/models/normalization.py
+++ b/models/normalization.py
@@ -4,12 +4,12 @@ from models.kin import KernelizedInstanceNorm
 from models.tin import ThumbInstanceNorm
 
 
-def get_normalization_layer(out_channels, normalization="kin"):
+def get_normalization_layer(num_features, normalization="kin"):
     if normalization == "kin":
-        return KernelizedInstanceNorm(out_channels=out_channels)
+        return KernelizedInstanceNorm(num_features=num_features)
     elif normalization == "tin":
-        return ThumbInstanceNorm(out_channels=out_channels)
+        return ThumbInstanceNorm(num_features=num_features)
     elif normalization == "in":
-        return nn.InstanceNorm2d(out_channels)
+        return nn.InstanceNorm2d(num_features)
     else:
         raise NotImplementedError

--- a/models/tests/test_kin.py
+++ b/models/tests/test_kin.py
@@ -11,7 +11,7 @@ def normalize(x):
 
 
 def test_forward_normal():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu')
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu')
     x = np.random.normal(size=(1, 3, 32, 32)).astype(np.float32)
     x = torch.FloatTensor(x)
 
@@ -23,7 +23,7 @@ def test_forward_normal():
 
 
 def test_init_kernel():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu')
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu')
     layer.init_kernel(kernel_padding=1, kernel_mode='constant')
 
     expected = np.ones(shape=(3, 3), dtype=np.float32) / 9
@@ -32,7 +32,7 @@ def test_init_kernel():
 
 
 def test_init_collection():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu')
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu')
     layer.init_collection(y_anchor_num=10, x_anchor_num=9)
 
     expected_mean_table = np.zeros(shape=(10, 9, 3))
@@ -43,7 +43,7 @@ def test_init_collection():
 
 
 def test_pad_table():
-    layer = KernelizedInstanceNorm(out_channels=1, device='cpu')
+    layer = KernelizedInstanceNorm(num_features=1, device='cpu')
 
     table = np.array(
         [
@@ -76,7 +76,7 @@ def test_pad_table():
 
 
 def test_forward_with_normal_instance_normalization():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu')
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu')
     layer.normal_instance_normalization = True
     x = np.random.normal(size=(1, 3, 32, 32)).astype(np.float32)
     x = torch.FloatTensor(x)
@@ -89,7 +89,7 @@ def test_forward_with_normal_instance_normalization():
 
 
 def test_forward_with_collection_mode():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu').eval()
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu').eval()
     layer.collection_mode = True
     layer.normal_instance_normalization = False
 
@@ -115,7 +115,7 @@ def test_forward_with_collection_mode():
 
 
 def test_forward_with_kernelized():
-    layer = KernelizedInstanceNorm(out_channels=3, device='cpu').eval()
+    layer = KernelizedInstanceNorm(num_features=3, device='cpu').eval()
     layer.collection_mode = True
     layer.normal_instance_normalization = False
 

--- a/models/tin.py
+++ b/models/tin.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 class ThumbInstanceNorm(nn.Module):
-    def __init__(self, out_channels=None, affine=True):
+    def __init__(self, num_features, affine=True):
         super(ThumbInstanceNorm, self).__init__()
         self.thumb_mean = None
         self.thumb_std = None
@@ -11,10 +11,10 @@ class ThumbInstanceNorm(nn.Module):
         self.collection_mode = False
         if affine:
             self.weight = nn.Parameter(
-                torch.ones(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             )
             self.bias = nn.Parameter(
-                torch.zeros(size=(1, out_channels, 1, 1), requires_grad=True)
+                torch.zeros(size=(1, num_features, 1, 1), requires_grad=True)
             )
 
     def calc_mean_std(self, feat, eps=1e-5):


### PR DESCRIPTION
To make the refactoring easier, rename the init argument `out_channels` in KIN and TIN to `num_features` which is used in [InstanceNorm2d](https://pytorch.org/docs/1.12/generated/torch.nn.InstanceNorm2d.html?highlight=instance#torch.nn.InstanceNorm2d). All tests were passed. And I had checked that all `out_channels` were replaced with `num_features`. So, I think everything works.