### PR TITLE
Refactor normalization config

### DIFF
--- a/F-LSeSim/combine.py
+++ b/F-LSeSim/combine.py
@@ -44,18 +44,18 @@ def main():
 
     path_base = os.path.join(
         path_root,
-        config["INFERENCE_SETTING"]["NORMALIZATION"],
+        config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"],
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
     )
 
-    combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}.png"
+    combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}.png"
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "kin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         path_base = os.path.join(
             path_base,
             f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}",
         )
-        combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}_{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}.png"
+        combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}_{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}.png"
 
     filenames = os.listdir(path_base)
     try:

--- a/F-LSeSim/inference.py
+++ b/F-LSeSim/inference.py
@@ -58,11 +58,11 @@ if __name__ == "__main__":
     config = read_yaml_config(opt.config)
 
     model = create_model(
-        opt, normalization_mode=config["INFERENCE_SETTING"]["NORMALIZATION"]
+        opt, norm_cfg=config["INFERENCE_SETTING"]["NORMALIZATION"]
     )  # create a model given opt.model and other options
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "tin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "tin":
         test_dataset = XInferenceDataset(
             root_X=config["INFERENCE_SETTING"]["TEST_DIR_X"],
             transform=test_transforms,
@@ -92,12 +92,12 @@ if __name__ == "__main__":
 
     save_path_base = os.path.join(
         save_path_root,
-        config["INFERENCE_SETTING"]["NORMALIZATION"],
+        config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"],
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
     )
     os.makedirs(save_path_base, exist_ok=True)
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "tin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "tin":
         model.init_thumbnail_instance_norm_for_whole_model()
         thumbnail = test_dataset.get_thumbnail()
         thumbnail_fake = model.inference(thumbnail)
@@ -123,7 +123,7 @@ if __name__ == "__main__":
                 ),
             )
 
-    elif config["INFERENCE_SETTING"]["NORMALIZATION"] == "kin":
+    elif config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         save_path_base_kin = os.path.join(
             save_path_base,
             f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}",

--- a/F-LSeSim/models/__init__.py
+++ b/F-LSeSim/models/__init__.py
@@ -54,7 +54,7 @@ def get_option_setter(model_name):
     return model_class.modify_commandline_options
 
 
-def create_model(opt, normalization_mode):
+def create_model(opt, norm_cfg):
     """Create a model given the option.
 
     This function warps the class CustomDatasetDataLoader.
@@ -65,6 +65,6 @@ def create_model(opt, normalization_mode):
         >>> model = create_model(opt)
     """
     model = find_model_using_name(opt.model)
-    instance = model(opt, normalization_mode=normalization_mode)
+    instance = model(opt, norm_cfg=norm_cfg)
     print("model [%s] was created" % type(instance).__name__)
     return instance

--- a/F-LSeSim/models/discriminator.py
+++ b/F-LSeSim/models/discriminator.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from models.downsample import Downsample
-from models.normalization import get_normalization_layer
+from models.normalization import make_norm_layer
 
 
 class DiscriminatorBasicBlock(nn.Module):
@@ -13,12 +13,13 @@ class DiscriminatorBasicBlock(nn.Module):
         out_features,
         do_downsample=True,
         do_instancenorm=True,
-        normalization="in",
+        norm_cfg=None,
     ):
         super().__init__()
 
         self.do_downsample = do_downsample
         self.do_instancenorm = do_instancenorm
+        self.norm_cfg = norm_cfg or {'type': 'in'}
 
         self.conv = nn.Conv2d(
             in_features, out_features, kernel_size=4, stride=1, padding=1
@@ -26,9 +27,7 @@ class DiscriminatorBasicBlock(nn.Module):
         self.leakyrelu = nn.LeakyReLU(0.2, True)
 
         if do_instancenorm:
-            self.instancenorm = get_normalization_layer(
-                out_features, normalization=normalization
-            )
+            self.instancenorm = make_norm_layer(self.norm_cfg, num_features=out_features)
 
         if do_downsample:
             self.downsample = Downsample(out_features)

--- a/F-LSeSim/models/networks.py
+++ b/F-LSeSim/models/networks.py
@@ -21,7 +21,7 @@ def define_G(
     no_antialias_up=False,
     gpu_ids=[],
     opt=None,
-    normalization="in",
+    norm_cfg=None,
 ):
     """
     Create a generator
@@ -39,10 +39,9 @@ def define_G(
     :param opt: options
     :return:
     """
-    norm_value = cyclegan_networks.get_norm_layer(norm)
 
     if netG == "resnet_9blocks":
-        net = Generator(normalization=normalization)
+        net = Generator(norm_cfg=norm_cfg or {'type': 'in'})
     elif netG == "stylegan2":
         net = stylegan_networks.StyleGAN2Generator(input_nc, output_nc, ngf, opt=opt)
     else:

--- a/F-LSeSim/models/normalization.py
+++ b/F-LSeSim/models/normalization.py
@@ -1,9 +1,13 @@
+from copy import deepcopy
+from typing import Any, Dict
+
 import torch.nn as nn
 
 from models.kin import KernelizedInstanceNorm
 from models.tin import ThumbInstanceNorm
 
 
+# TODO: To be deprecated
 def get_normalization_layer(num_features, normalization="kin"):
     if normalization == "kin":
         return KernelizedInstanceNorm(num_features=num_features)
@@ -13,3 +17,37 @@ def get_normalization_layer(num_features, normalization="kin"):
         return nn.InstanceNorm2d(num_features)
     else:
         raise NotImplementedError
+
+
+def make_norm_layer(norm_cfg: Dict[str, Any], **kwargs: Any):
+    """
+    Create normalization layer based on given config and arguments.
+
+    Args:
+        norm_cfg (Dict[str, Any]): A dict of keyword arguments of normalization layer.
+            It must have a key 'type' to specify which normalization layers will be used.
+            It accepts upper case argument.
+        **kwargs (Any): The keyword arguments are used to overwrite `norm_cfg`.
+
+    Returns:
+        nn.Module: A layer object.
+    """
+    norm_cfg = deepcopy(norm_cfg)
+    norm_cfg = {k.lower(): v for k, v in norm_cfg.items()}
+
+    norm_cfg.update(kwargs)
+
+    if 'type' not in norm_cfg:
+        raise ValueError('"type" wasn\'t specified.')
+
+    norm_type = norm_cfg['type']
+    del norm_cfg['type']
+
+    if norm_type == 'in':
+        return nn.InstanceNorm2d(**norm_cfg)
+    elif norm_type == 'tin':
+        return ThumbInstanceNorm(**norm_cfg)
+    elif norm_type == 'kin':
+        return KernelizedInstanceNorm(**norm_cfg)
+    else:
+        raise ValueError(f'Unknown norm type: {norm_type}.')

--- a/F-LSeSim/models/sc_model.py
+++ b/F-LSeSim/models/sc_model.py
@@ -106,7 +106,7 @@ class SCModel(BaseModel):
 
         return parser
 
-    def __init__(self, opt, normalization_mode="in"):
+    def __init__(self, opt, norm_cfg=None):
         """
         Initialize the translation losses
         :param opt: stores all the experiment flags; needs to be a subclass of BaseOptions
@@ -119,6 +119,7 @@ class SCModel(BaseModel):
         # specify the models you want to save to the disk
         self.model_names = ["G", "D"] if self.isTrain else ["G"]
         # define the networks
+        self.norm_cfg = norm_cfg or {'type': 'in'}
         self.netG = networks.define_G(
             opt.input_nc,
             opt.output_nc,
@@ -132,9 +133,8 @@ class SCModel(BaseModel):
             opt.no_antialias_up,
             self.gpu_ids,
             opt,
-            normalization=normalization_mode,
+            norm_cfg=self.norm_cfg,
         )
-        self.normalization_mode = normalization_mode
 
         # define the training process
         if self.isTrain:
@@ -278,7 +278,7 @@ class SCModel(BaseModel):
         return Y_fake
 
     def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
-        assert self.normalization_mode == "kin"
+        assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)

--- a/F-LSeSim/train.py
+++ b/F-LSeSim/train.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     print("The number of training images = %d" % dataset_size)
 
     model = create_model(
-        opt, normalization_mode="in"
+        opt, norm_cfg={'type': 'in'}
     )  # create a model given opt.model and other options
 
     total_iters = 0  # the total number of training iterations

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ You can adjust `KIN_PADDING` and `KIN_KERNEL` for inference.
 ```yaml
 INFERENCE_SETTING:
   ...
-  NORMALIZATION: "kin"
+  NORMALIZATION:
+      TYPE: "kin"
   KIN_PADDING: 3 # for kin
   KIN_KERNEL: "constant" #constant or gaussian
 ```
@@ -110,15 +111,17 @@ Please provide the path of the `THUMBNAIL`.
 ```yaml
 INFERENCE_SETTING:
   ...
-  NORMALIZATION: "tin"
+  NORMALIZATION:
+      TYPE: "tin"
   THUMBNAIL: "./data/example/testX/thumbnail.png"
 ```
 ### Instance normalization
-Specification of `NORMALIZATION: in` is enough.
+Specification of `NORMALIZATION.TYPE: in` is enough.
 ```yaml
 INFERENCE_SETTING:
   ...
-  NORMALIZATION: "in"
+  NORMALIZATION:
+      TYPE: "in"
 ```
 ## Training framework options
 Besides `CUT`, `LSeSim` and `CycleGAN` are also provided. For each experiment, you should rename `EXPERIMENT_NAME` to avoid overwritting.

--- a/appendix/proof_of_concept.py
+++ b/appendix/proof_of_concept.py
@@ -68,7 +68,7 @@ def main():
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization=config["INFERENCE_SETTING"]["NORMALIZATION"],
+        norm_cfg=config["INFERENCE_SETTING"]["NORMALIZATION"],
         isTrain=False,
     )
 

--- a/combine.py
+++ b/combine.py
@@ -47,22 +47,22 @@ def main():
 
     path_base = os.path.join(
         path_root,
-        config["INFERENCE_SETTING"]["NORMALIZATION"],
+        config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"],
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
     )
 
     combined_image_name = f"combined_" \
-                          f"{config['INFERENCE_SETTING']['NORMALIZATION']}_" \
+                          f"{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_" \
                           f"{config['INFERENCE_SETTING']['MODEL_VERSION']}.png"
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "kin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         path_base = os.path.join(
             path_base,
             f"{config['INFERENCE_SETTING']['KIN_KERNEL']}"
             f"_{config['INFERENCE_SETTING']['KIN_PADDING']}",
         )
         combined_image_name = f"combined_" \
-            f"{config['INFERENCE_SETTING']['NORMALIZATION']}" \
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}" \
             f"_{config['INFERENCE_SETTING']['MODEL_VERSION']}_" \
             f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_" \
             f"{config['INFERENCE_SETTING']['KIN_PADDING']}.png"

--- a/data/example/config.yaml
+++ b/data/example/config.yaml
@@ -39,7 +39,8 @@ INFERENCE_SETTING:
   TEST_DIR_X: "./data/example/testX/HE_cropped/"
   MODEL_VERSION: "10"
   SAVE_ORIGINAL_IMAGE: False
-  NORMALIZATION: "kin"
+  NORMALIZATION:
+    TYPE: 'kin'
   THUMBNAIL: "./data/example/testX/HE_cropped/thumbnail.png" #"None" # set to "None" if it's not required
   KIN_PADDING: 3 # for kin
   KIN_KERNEL: "constant" #constant or gaussian

--- a/inference.py
+++ b/inference.py
@@ -34,7 +34,7 @@ def main():
         isTrain=False,
     )
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "tin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "tin":
         test_dataset = XInferenceDataset(
             root_X=config["INFERENCE_SETTING"]["TEST_DIR_X"],
             transform=test_transforms,
@@ -71,12 +71,12 @@ def main():
 
     save_path_base = os.path.join(
         save_path_root,
-        config["INFERENCE_SETTING"]["NORMALIZATION"],
+        config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"],
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
     )
     os.makedirs(save_path_base, exist_ok=True)
 
-    if config["INFERENCE_SETTING"]["NORMALIZATION"] == "tin":
+    if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "tin":
         model.init_thumbnail_instance_norm_for_whole_model()
         thumbnail = test_dataset.get_thumbnail()
         thumbnail_fake = model.inference(thumbnail)
@@ -105,7 +105,7 @@ def main():
                 ),
             )
 
-    elif config["INFERENCE_SETTING"]["NORMALIZATION"] == "kin":
+    elif config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         save_path_base_kin = os.path.join(
             save_path_base,
             f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_"

--- a/inference.py
+++ b/inference.py
@@ -30,7 +30,7 @@ def main():
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization=config["INFERENCE_SETTING"]["NORMALIZATION"],
+        norm_cfg=config["INFERENCE_SETTING"]["NORMALIZATION"],
         isTrain=False,
     )
 

--- a/models/cut.py
+++ b/models/cut.py
@@ -22,7 +22,7 @@ from models.tin import (
 class ContrastiveModel(BaseModel):
     # instance normalization can be different from the
     # one specified during training
-    def __init__(self, config, normalization="in"):
+    def __init__(self, config, norm_cfg=None):
         BaseModel.__init__(self, config)
         self.model_names = ["D_Y", "G", "H"]
         self.loss_names = ["G_adv", "D_Y", "G", "NCE"]
@@ -31,12 +31,12 @@ class ContrastiveModel(BaseModel):
             self.loss_names += ["NCE_Y"]
             self.visual_names += ["Y_idt"]
 
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
         # Discrimnator would not be used during inference,
         # so specification of instane normalization is not required
         self.D_Y = Discriminator().to(self.device)
 
-        self.G = Generator(normalization=normalization).to(self.device)
+        self.G = Generator(norm_cfg=norm_cfg).to(self.device)
         self.H = Head().to(self.device)
 
         self.opt_D_Y = optim.Adam(
@@ -101,7 +101,7 @@ class ContrastiveModel(BaseModel):
         return Y_fake
 
     def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+        assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)

--- a/models/cyclegan.py
+++ b/models/cyclegan.py
@@ -24,7 +24,7 @@ from models.tin import (
 class CycleGanModel(BaseModel):
     # instance normalization can be different
     # from the one specified during training
-    def __init__(self, config, normalization="in"):
+    def __init__(self, config, norm_cfg=None):
         BaseModel.__init__(self, config)
         self.model_names = ["G_X2Y", "G_Y2X", "D_X", "D_Y"]
         self.loss_names = [
@@ -48,11 +48,11 @@ class CycleGanModel(BaseModel):
             "recovered_Y",
         ]
 
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
         # Discrimnator would not be used during inference,
         # so specification of instane normalization is not required
-        self.G_X2Y = Generator(normalization=normalization).to(self.device)
-        self.G_Y2X = Generator(normalization=normalization).to(self.device)
+        self.G_X2Y = Generator(norm_cfg=norm_cfg).to(self.device)
+        self.G_Y2X = Generator(norm_cfg=norm_cfg).to(self.device)
         self.D_X = Discriminator(avg_pooling=True).to(self.device)
         self.D_Y = Discriminator(avg_pooling=True).to(self.device)
 
@@ -123,7 +123,7 @@ class CycleGanModel(BaseModel):
         return Y_fake
 
     def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+        assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)

--- a/models/discriminator.py
+++ b/models/discriminator.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from models.downsample import Downsample
-from models.normalization import get_normalization_layer
+from models.normalization import make_norm_layer
 
 
 class DiscriminatorBasicBlock(nn.Module):
@@ -13,10 +13,11 @@ class DiscriminatorBasicBlock(nn.Module):
         out_features,
         do_downsample=True,
         do_instancenorm=True,
-        normalization="in",
+        norm_cfg=None
     ):
         super().__init__()
 
+        self.norm_cfg = norm_cfg or {'type': 'in'}
         self.do_downsample = do_downsample
         self.do_instancenorm = do_instancenorm
 
@@ -26,9 +27,7 @@ class DiscriminatorBasicBlock(nn.Module):
         self.leakyrelu = nn.LeakyReLU(0.2, True)
 
         if do_instancenorm:
-            self.instancenorm = get_normalization_layer(
-                out_features, normalization=normalization
-            )
+            self.instancenorm = make_norm_layer(self.norm_cfg, num_features=out_features)
 
         if do_downsample:
             self.downsample = Downsample(out_features)

--- a/models/generator.py
+++ b/models/generator.py
@@ -2,29 +2,29 @@ import torch
 import torch.nn as nn
 
 from models.downsample import Downsample
-from models.normalization import get_normalization_layer
+from models.normalization import make_norm_layer
 from models.upsample import Upsample
 
 
 class ResnetBlock(nn.Module):
-    def __init__(self, features, normalization="in"):
+    def __init__(self, features, norm_cfg=None):
         super().__init__()
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
         self.model = nn.Sequential(
             nn.ReflectionPad2d(1),
             nn.Conv2d(features, features, kernel_size=3),
-            get_normalization_layer(features, normalization=normalization),
+            make_norm_layer(self.norm_cfg, num_features=features),
             nn.ReLU(True),
             nn.ReflectionPad2d(1),
             nn.Conv2d(features, features, kernel_size=3),
-            get_normalization_layer(features, normalization=normalization),
+            make_norm_layer(self.norm_cfg, num_features=features),
         )
 
     def forward(self, x):
         return x + self.model(x)
 
     def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+        assert self.norm_cfg['type'] == "kin"
         x_residual = x
         x = self.model[:2](x)
         x = self.model[2](
@@ -52,22 +52,20 @@ class GeneratorBasicBlock(nn.Module):
         out_features,
         do_upsample=False,
         do_downsample=False,
-        normalization="in",
+        norm_cfg=None,
     ):
         super().__init__()
 
         self.do_upsample = do_upsample
         self.do_downsample = do_downsample
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
 
         if self.do_upsample:
             self.upsample = Upsample(in_features)
         self.conv = nn.Conv2d(
             in_features, out_features, kernel_size=3, stride=1, padding=1
         )
-        self.instancenorm = get_normalization_layer(
-            out_features, normalization=normalization
-        )
+        self.instancenorm = make_norm_layer(self.norm_cfg, num_features=out_features)
         self.relu = nn.ReLU(True)
         if self.do_downsample:
             self.downsample = Downsample(out_features)
@@ -93,7 +91,7 @@ class GeneratorBasicBlock(nn.Module):
         return x_hook, x
 
     def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+        assert self.norm_cfg['type'] == "kin"
         if self.do_upsample:
             x = self.upsample(x)
         x = self.conv(x)
@@ -118,16 +116,16 @@ class GeneratorBasicBlock(nn.Module):
 
 class Generator(nn.Module):
     def __init__(
-        self, in_channels=3, features=64, residuals=9, normalization="in"
+        self, in_channels=3, features=64, residuals=9, norm_cfg=None,
     ):
         super().__init__()
         self.residuals = residuals
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
 
         self.reflectionpad = nn.ReflectionPad2d(3)
         self.block1 = nn.Sequential(
             nn.Conv2d(in_channels, features, kernel_size=7),
-            get_normalization_layer(features, normalization=normalization),
+            make_norm_layer(self.norm_cfg, num_features=features),
             nn.ReLU(True),
         )
 
@@ -136,19 +134,19 @@ class Generator(nn.Module):
             features * 2,
             do_upsample=False,
             do_downsample=True,
-            normalization=normalization,
+            norm_cfg=self.norm_cfg,
         )
         self.downsampleblock3 = GeneratorBasicBlock(
             features * 2,
             features * 4,
             do_upsample=False,
             do_downsample=True,
-            normalization=normalization,
+            norm_cfg=self.norm_cfg,
         )
 
         self.resnetblocks4 = nn.Sequential(
             *[
-                ResnetBlock(features * 4, normalization=normalization)
+                ResnetBlock(features * 4, norm_cfg=self.norm_cfg)
                 for _ in range(residuals)
             ]
         )
@@ -158,14 +156,14 @@ class Generator(nn.Module):
             features * 2,
             do_upsample=True,
             do_downsample=False,
-            normalization=normalization,
+            norm_cfg=self.norm_cfg,
         )
         self.upsampleblock6 = GeneratorBasicBlock(
             features * 2,
             features,
             do_upsample=True,
             do_downsample=False,
-            normalization=normalization,
+            norm_cfg=self.norm_cfg,
         )
 
         self.block7 = nn.Sequential(
@@ -224,7 +222,7 @@ class Generator(nn.Module):
         return x, feature_maps
 
     def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+        assert self.norm_cfg['type'] == "kin"
         x = self.reflectionpad(x)
         x = self.block1[0](x)
         x = self.block1[1](

--- a/models/model.py
+++ b/models/model.py
@@ -2,6 +2,7 @@ from models.cut import ContrastiveModel
 from models.cyclegan import CycleGanModel
 
 
+# XXX: Check if isTrain is used
 def get_model(config, model_name="CUT", norm_cfg=None, isTrain=True):
     if model_name == "CUT":
         model = ContrastiveModel(config, norm_cfg=norm_cfg)

--- a/models/model.py
+++ b/models/model.py
@@ -2,11 +2,11 @@ from models.cut import ContrastiveModel
 from models.cyclegan import CycleGanModel
 
 
-def get_model(config, model_name="CUT", normalization="in", isTrain=True):
+def get_model(config, model_name="CUT", norm_cfg=None, isTrain=True):
     if model_name == "CUT":
-        model = ContrastiveModel(config, normalization=normalization)
+        model = ContrastiveModel(config, norm_cfg=norm_cfg)
     elif model_name == "cycleGAN":
-        model = CycleGanModel(config, normalization=normalization)
+        model = CycleGanModel(config, norm_cfg=norm_cfg)
     elif model_name == "LSeSim":
         print("Please use the scripts prepared in the F-LSeSim folder")
         raise NotImplementedError

--- a/models/normalization.py
+++ b/models/normalization.py
@@ -7,6 +7,7 @@ from models.kin import KernelizedInstanceNorm
 from models.tin import ThumbInstanceNorm
 
 
+# TODO: To be deprecated
 def get_normalization_layer(num_features, normalization="kin"):
     if normalization == "kin":
         return KernelizedInstanceNorm(num_features=num_features)
@@ -20,10 +21,12 @@ def get_normalization_layer(num_features, normalization="kin"):
 
 def make_norm_layer(norm_cfg: Dict[str, Any], **kwargs: Any):
     """
+    Create normalization layer based on given config and arguments.
 
     Args:
         norm_cfg (Dict[str, Any]): A dict of keyword arguments of normalization layer.
             It must have a key 'type' to specify which normalization layers will be used.
+            It accepts upper case argument.
         **kwargs (Any): The keyword arguments are used to overwrite `norm_cfg`.
 
     Returns:

--- a/models/normalization.py
+++ b/models/normalization.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+from typing import Any, Dict
+
 import torch.nn as nn
 
 from models.kin import KernelizedInstanceNorm
@@ -13,3 +16,33 @@ def get_normalization_layer(num_features, normalization="kin"):
         return nn.InstanceNorm2d(num_features)
     else:
         raise NotImplementedError
+
+
+def make_norm_layer(norm_cfg: Dict[str, Any], **kwargs: Any):
+    """
+
+    Args:
+        norm_cfg (Dict[str, Any]): A dict of keyword arguments of normalization layer.
+            It must have a key 'type' to specify which normalization layers will be used.
+        **kwargs (Any): The keyword arguments are used to overwrite `norm_cfg`.
+
+    Returns:
+        nn.Module: A layer object.
+    """
+    norm_cfg = deepcopy(norm_cfg)
+    norm_cfg.update(kwargs)
+
+    if 'type' not in norm_cfg:
+        raise ValueError('"type" wasn\'t specified.')
+
+    norm_type = norm_cfg['type']
+    del norm_cfg['type']
+
+    if norm_type == 'in':
+        return nn.InstanceNorm2d(**norm_cfg)
+    elif norm_type == 'tin':
+        return ThumbInstanceNorm(**norm_cfg)
+    elif norm_type == 'kin':
+        return KernelizedInstanceNorm(**norm_cfg)
+    else:
+        raise ValueError(f'Unknown norm type: {norm_type}.')

--- a/models/normalization.py
+++ b/models/normalization.py
@@ -30,6 +30,8 @@ def make_norm_layer(norm_cfg: Dict[str, Any], **kwargs: Any):
         nn.Module: A layer object.
     """
     norm_cfg = deepcopy(norm_cfg)
+    norm_cfg = {k.lower(): v for k, v in norm_cfg.items()}
+
     norm_cfg.update(kwargs)
 
     if 'type' not in norm_cfg:

--- a/models/tests/test_cut.py
+++ b/models/tests/test_cut.py
@@ -29,7 +29,7 @@ def in_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization="in",
+        norm_cfg={'type': 'in'},
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
@@ -42,7 +42,7 @@ def kin_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization="kin",
+        norm_cfg={'type': 'kin'},
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])

--- a/models/tests/test_cyclegan.py
+++ b/models/tests/test_cyclegan.py
@@ -29,7 +29,7 @@ def in_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization="in",
+        norm_cfg={'type': 'in'},
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
@@ -42,7 +42,7 @@ def kin_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        normalization="kin",
+        norm_cfg={'type': 'kin'},
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])


### PR DESCRIPTION
1. Reimplement `get_normalization_layer` as `make_norm_layer`. The new function is more flexible that it can receive custom keyword arguments.
2. Change the type of yaml config field `NORMALIZATION`. The original field is a string which denotes the type of normalization layer. The new field is a dict which can be passed to `make_norm_layer` directly.