### PR TITLE
Pass kernel size and kernel type and padding as init arguments

### DIFF
--- a/F-LSeSim/combine.py
+++ b/F-LSeSim/combine.py
@@ -53,7 +53,7 @@ def main():
     if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         path_base = os.path.join(
             path_base,
-            f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}",
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
         )
         combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}_{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}.png"
 

--- a/F-LSeSim/combine.py
+++ b/F-LSeSim/combine.py
@@ -55,7 +55,7 @@ def main():
             path_base,
             f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
         )
-        combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}_{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}.png"
+        combined_image_name = f"combined_{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}_{config['INFERENCE_SETTING']['MODEL_VERSION']}_{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}.png"
 
     filenames = os.listdir(path_base)
     try:

--- a/F-LSeSim/inference.py
+++ b/F-LSeSim/inference.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     elif config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         save_path_base_kin = os.path.join(
             save_path_base,
-            f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_{config['INFERENCE_SETTING']['KIN_PADDING']}",
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
         )
         os.makedirs(save_path_base_kin, exist_ok=True)
         y_anchor_num, x_anchor_num = test_dataset.get_boundary()
@@ -134,8 +134,6 @@ if __name__ == "__main__":
         model.init_kernelized_instance_norm_for_whole_model(
             y_anchor_num=y_anchor_num + 1,
             x_anchor_num=x_anchor_num + 1,
-            kernel_padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
-            kernel_mode=config["INFERENCE_SETTING"]["KIN_KERNEL"],
         )
         for idx, data in enumerate(test_loader):
             print(f"Caching {idx}", end="\r")
@@ -149,12 +147,9 @@ if __name__ == "__main__":
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
-                padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
             )
 
-        model.use_kernelized_instance_norm_for_whole_model(
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"]
-        )
+        model.use_kernelized_instance_norm_for_whole_model()
         for idx, data in enumerate(test_loader):
             print(f"Processing {idx}", end="\r")
             X, X_path, y_anchor, x_anchor = (
@@ -167,7 +162,6 @@ if __name__ == "__main__":
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
-                padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
             )
             if config["INFERENCE_SETTING"]["SAVE_ORIGINAL_IMAGE"]:
                 save_image(

--- a/F-LSeSim/models/discriminator.py
+++ b/F-LSeSim/models/discriminator.py
@@ -20,6 +20,7 @@ class DiscriminatorBasicBlock(nn.Module):
         self.do_downsample = do_downsample
         self.do_instancenorm = do_instancenorm
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         self.conv = nn.Conv2d(
             in_features, out_features, kernel_size=4, stride=1, padding=1

--- a/F-LSeSim/models/generator.py
+++ b/F-LSeSim/models/generator.py
@@ -10,6 +10,7 @@ class ResnetBlock(nn.Module):
     def __init__(self, features, norm_cfg=None):
         super().__init__()
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         self.model = nn.Sequential(
             nn.ReflectionPad2d(1),
             nn.Conv2d(features, features, kernel_size=3),
@@ -55,6 +56,7 @@ class GeneratorBasicBlock(nn.Module):
         self.do_upsample = do_upsample
         self.do_downsample = do_downsample
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         if self.do_upsample:
             self.upsample = Upsample(in_features)
@@ -113,6 +115,7 @@ class Generator(nn.Module):
         super().__init__()
         self.residuals = residuals
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         self.reflectionpad = nn.ReflectionPad2d(3)
         self.block1 = nn.Sequential(

--- a/F-LSeSim/models/generator.py
+++ b/F-LSeSim/models/generator.py
@@ -24,13 +24,13 @@ class ResnetBlock(nn.Module):
     def forward(self, x):
         return x + self.model(x)
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         x_residual = x
         x = self.model[:2](x)
-        x = self.model[2](x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding)
+        x = self.model[2](x, y_anchor=y_anchor, x_anchor=x_anchor)
         x = self.model[3:6](x)
-        x = self.model[6](x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding)
+        x = self.model[6](x, y_anchor=y_anchor, x_anchor=x_anchor)
         return x_residual + x
 
     def analyze_feature_map(self, x):
@@ -88,12 +88,12 @@ class GeneratorBasicBlock(nn.Module):
             x = self.downsample(x)
         return x_hook, x
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         if self.do_upsample:
             x = self.upsample(x)
         x = self.conv(x)
-        x = self.instancenorm(x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding)
+        x = self.instancenorm(x, y_anchor=y_anchor, x_anchor=x_anchor)
         x = self.relu(x)
         if self.do_downsample:
             x = self.downsample(x)
@@ -215,27 +215,27 @@ class Generator(nn.Module):
         x = self.block7(x)
         return x, feature_maps
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         x = self.reflectionpad(x)
         x = self.block1[0](x)
-        x = self.block1[1](x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding)
+        x = self.block1[1](x, y_anchor=y_anchor, x_anchor=x_anchor)
         x = self.block1[2](x)
         x = self.downsampleblock2.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.downsampleblock3.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         for resnetblock in self.resnetblocks4:
             x = resnetblock.forward_with_anchor(
-                x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                x, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         x = self.upsampleblock5.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.upsampleblock6.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.block7(x)
         return x

--- a/F-LSeSim/models/kin.py
+++ b/F-LSeSim/models/kin.py
@@ -5,9 +5,35 @@ from utils.util import get_kernel
 
 
 class KernelizedInstanceNorm(nn.Module):
+    """
 
-    def __init__(self, num_features, eps=0, affine=True, device="cuda"):
+    Attributes:
+        num_features (int): The number of input features.
+        kernel_size (int): The size of kernel used to kernelize.
+        kernel_type (str): The kernel type. It must be either 'constant' or 'gaussian'.
+        padding (int): The padding size of cache table.
+        eps (float): A value added to the denominator for numerical stability.
+        affine (bool): A boolean value that when set to True, this module has learnable
+            affine parameters, initialized the same way as done for batch normalization.
+        device (str): The device to place the variables.
+    """
+
+    def __init__(
+        self,
+        num_features,
+        kernel_size=3,
+        kernel_type='gaussian',
+        padding=1,
+        eps=0,
+        affine=True,
+        device="cuda",
+    ):
         super(KernelizedInstanceNorm, self).__init__()
+
+        if kernel_size % 2 == 0:
+            raise ValueError(
+                f'kernel_size must be an odd number. But got {kernel_size}.',
+            )
 
         # if use normal instance normalization during evaluation mode
         self.normal_instance_normalization = False
@@ -17,10 +43,19 @@ class KernelizedInstanceNorm(nn.Module):
         self.collection_mode = False
 
         self.num_features = num_features
+        self.kernel_size = kernel_size
+        self.kernel_type = kernel_type
+        self.padding = padding
         self.eps = eps
+        self.affine = affine
         self.device = device
 
-        if affine:
+        self.kernel = get_kernel(
+            padding=(self.kernel_size - 1) // 2,
+            mode=self.kernel_type,
+        ).to(self.device)
+
+        if self.affine:
             self.weight = nn.Parameter(
                 torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)
@@ -43,17 +78,11 @@ class KernelizedInstanceNorm(nn.Module):
             self.device
         )
 
-    def init_kernel(self, kernel_padding, kernel_mode):
-        # TODO: 1. Consider to use strategy pattern
-        # TODO: 2. padding => kernel_size, and raise an error for even number
-        kernel = get_kernel(padding=kernel_padding, mode=kernel_mode)
-        self.kernel = kernel.to(self.device)
-
-    def pad_table(self, padding):
+    def pad_table(self):
         # modify
         # padded table shape inconsisency
         # TODO: Don't permute the dimensions
-        pad_func = nn.ReplicationPad2d((padding, padding, padding, padding))
+        pad_func = nn.ReplicationPad2d((self.padding, self.padding, self.padding, self.padding))
         self.padded_mean_table = pad_func(
             self.mean_table.permute(2, 0, 1).unsqueeze(0)
         )  # [H, W, C] -> [C, H, W] -> [N, C, H, W]
@@ -67,7 +96,7 @@ class KernelizedInstanceNorm(nn.Module):
         x = (x - x_mean) / x_std  # * self.weight + self.bias
         return x
 
-    def forward(self, x, y_anchor=None, x_anchor=None, padding=1):
+    def forward(self, x, y_anchor=None, x_anchor=None):
         # TODO: Do not reply on self.training
         if self.training or self.normal_instance_normalization:
             return self.forward_normal(x)
@@ -99,9 +128,9 @@ class KernelizedInstanceNorm(nn.Module):
                 assert x.shape[0] == 1
 
                 top = y_anchor
-                down = y_anchor + 2 * padding + 1
+                down = y_anchor + 2 * self.padding + 1
                 left = x_anchor
-                right = x_anchor + 2 * padding + 1
+                right = x_anchor + 2 * self.padding + 1
                 x_mean = self.padded_mean_table[
                     :, :, top:down, left:right
                 ]  # 1, C, H, W
@@ -123,7 +152,7 @@ def not_use_kernelized_instance_norm(model):
 
 
 def init_kernelized_instance_norm(
-    model, y_anchor_num, x_anchor_num, kernel_padding, kernel_mode
+    model, y_anchor_num, x_anchor_num,
 ):
     for _, layer in model.named_modules():
         if isinstance(layer, KernelizedInstanceNorm):
@@ -132,14 +161,11 @@ def init_kernelized_instance_norm(
             layer.init_collection(
                 y_anchor_num=y_anchor_num, x_anchor_num=x_anchor_num
             )
-            layer.init_kernel(
-                kernel_padding=kernel_padding, kernel_mode=kernel_mode
-            )
 
 
-def use_kernelized_instance_norm(model, padding=1):
+def use_kernelized_instance_norm(model):
     for _, layer in model.named_modules():
         if isinstance(layer, KernelizedInstanceNorm):
-            layer.pad_table(padding=padding)
+            layer.pad_table()
             layer.collection_mode = False
             layer.normal_instance_normalization = False

--- a/F-LSeSim/models/kin.py
+++ b/F-LSeSim/models/kin.py
@@ -11,7 +11,7 @@ class KernelizedInstanceNorm(nn.Module):
         num_features (int): The number of input features.
         kernel_size (int): The size of kernel used to kernelize.
         kernel_type (str): The kernel type. It must be either 'constant' or 'gaussian'.
-        padding (int): The padding size of cache table.
+        padding (int): The padding size of cache table. It must be `(kernel_size - 1) / 2`.
         eps (float): A value added to the denominator for numerical stability.
         affine (bool): A boolean value that when set to True, this module has learnable
             affine parameters, initialized the same way as done for batch normalization.
@@ -33,6 +33,11 @@ class KernelizedInstanceNorm(nn.Module):
         if kernel_size % 2 == 0:
             raise ValueError(
                 f'kernel_size must be an odd number. But got {kernel_size}.',
+            )
+
+        if padding != (kernel_size - 1) // 2:
+            raise ValueError(
+                f'padding must be (kernel_size - 1) / 2. But got {padding}.'
             )
 
         # if use normal instance normalization during evaluation mode

--- a/F-LSeSim/models/sc_model.py
+++ b/F-LSeSim/models/sc_model.py
@@ -278,13 +278,13 @@ class SCModel(BaseModel):
             Y_fake, _ = self.netG(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
+    def inference_with_anchor(self, X, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.netG.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                X, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         return Y_fake
 
@@ -447,18 +447,16 @@ class SCModel(BaseModel):
         not_use_thumbnail_instance_norm(self.netG)
 
     def init_kernelized_instance_norm_for_whole_model(
-        self, y_anchor_num, x_anchor_num, kernel_padding=1, kernel_mode="constant"
+        self, y_anchor_num, x_anchor_num,
     ):
         init_kernelized_instance_norm(
             self.netG,
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
-            kernel_padding=kernel_padding,
-            kernel_mode=kernel_mode,
         )
 
-    def use_kernelized_instance_norm_for_whole_model(self, padding=1):
-        use_kernelized_instance_norm(self.netG, padding=padding)
+    def use_kernelized_instance_norm_for_whole_model(self):
+        use_kernelized_instance_norm(self.netG)
 
     def not_use_kernelized_instance_norm_for_whole_model(self):
         not_use_kernelized_instance_norm(self.netG)

--- a/F-LSeSim/models/sc_model.py
+++ b/F-LSeSim/models/sc_model.py
@@ -120,6 +120,7 @@ class SCModel(BaseModel):
         self.model_names = ["G", "D"] if self.isTrain else ["G"]
         # define the networks
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         self.netG = networks.define_G(
             opt.input_nc,
             opt.output_nc,

--- a/README.md
+++ b/README.md
@@ -97,14 +97,15 @@ python3 transfer.py -c ./data/$your_folder/config.yaml --skip_cropping
 ## Inference options
 Besides `kernelized instance normalization`, `thumbnail instance normalization` and `instance normalization` are also provided.
 ### Kernelized instance normalization
-You can adjust `KIN_PADDING` and `KIN_KERNEL` for inference.
+You can adjust `NORMALIZATION.PADDING`, `NORMALIZATION.KERNEL_TYPE`, and `NORMALIZATION.KERNEL_SIZE` for inference.
 ```yaml
 INFERENCE_SETTING:
   ...
   NORMALIZATION:
       TYPE: "kin"
-  KIN_PADDING: 3 # for kin
-  KIN_KERNEL: "constant" #constant or gaussian
+      PADDING: 1
+      KERNEL_TYPE: "constant"  # constant or gaussian
+      KERNEL_SIZE: 3
 ```
 ### Thumbnail instance normalization
 Please provide the path of the `THUMBNAIL`.

--- a/combine.py
+++ b/combine.py
@@ -58,14 +58,14 @@ def main():
     if config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         path_base = os.path.join(
             path_base,
-            f"{config['INFERENCE_SETTING']['KIN_KERNEL']}"
-            f"_{config['INFERENCE_SETTING']['KIN_PADDING']}",
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}"
+            f"_{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
         )
         combined_image_name = f"combined_" \
             f"{config['INFERENCE_SETTING']['NORMALIZATION']['TYPE']}" \
             f"_{config['INFERENCE_SETTING']['MODEL_VERSION']}_" \
-            f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_" \
-            f"{config['INFERENCE_SETTING']['KIN_PADDING']}.png"
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_" \
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}.png"
 
     filenames = os.listdir(path_base)
     try:

--- a/data/example/config.yaml
+++ b/data/example/config.yaml
@@ -41,6 +41,7 @@ INFERENCE_SETTING:
   SAVE_ORIGINAL_IMAGE: False
   NORMALIZATION:
     TYPE: 'kin'
+    PADDING: 1
+    KERNEL_TYPE: 'constant'
+    KERNEL_SIZE: 3
   THUMBNAIL: "./data/example/testX/HE_cropped/thumbnail.png" #"None" # set to "None" if it's not required
-  KIN_PADDING: 3 # for kin
-  KIN_KERNEL: "constant" #constant or gaussian

--- a/inference.py
+++ b/inference.py
@@ -108,8 +108,8 @@ def main():
     elif config["INFERENCE_SETTING"]["NORMALIZATION"]["TYPE"] == "kin":
         save_path_base_kin = os.path.join(
             save_path_base,
-            f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_"
-            f"{config['INFERENCE_SETTING']['KIN_PADDING']}",
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_"
+            f"{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
         )
         os.makedirs(save_path_base_kin, exist_ok=True)
         y_anchor_num, x_anchor_num = test_dataset.get_boundary()
@@ -118,8 +118,6 @@ def main():
         model.init_kernelized_instance_norm_for_whole_model(
             y_anchor_num=y_anchor_num + 1,
             x_anchor_num=x_anchor_num + 1,
-            kernel_padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
-            kernel_mode=config["INFERENCE_SETTING"]["KIN_KERNEL"],
         )
         for idx, data in enumerate(test_loader):
             print(f"Caching {idx}", end="\r")
@@ -133,12 +131,9 @@ def main():
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
-                padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
             )
 
-        model.use_kernelized_instance_norm_for_whole_model(
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"]
-        )
+        model.use_kernelized_instance_norm_for_whole_model()
         for idx, data in enumerate(test_loader):
             print(f"Processing {idx}", end="\r")
             X, X_path, y_anchor, x_anchor = (
@@ -151,7 +146,6 @@ def main():
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
-                padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
             )
             if config["INFERENCE_SETTING"]["SAVE_ORIGINAL_IMAGE"]:
                 save_image(

--- a/models/cut.py
+++ b/models/cut.py
@@ -32,6 +32,7 @@ class ContrastiveModel(BaseModel):
             self.visual_names += ["Y_idt"]
 
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         # Discrimnator would not be used during inference,
         # so specification of instane normalization is not required
         self.D_Y = Discriminator().to(self.device)

--- a/models/cut.py
+++ b/models/cut.py
@@ -100,13 +100,13 @@ class ContrastiveModel(BaseModel):
             Y_fake = self.G(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
+    def inference_with_anchor(self, X, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                X, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         return Y_fake
 
@@ -197,19 +197,15 @@ class ContrastiveModel(BaseModel):
         self,
         y_anchor_num,
         x_anchor_num,
-        kernel_padding=1,
-        kernel_mode="constant",
     ):
         init_kernelized_instance_norm(
             self.G,
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
-            kernel_padding=kernel_padding,
-            kernel_mode=kernel_mode,
         )
 
-    def use_kernelized_instance_norm_for_whole_model(self, padding=1):
-        use_kernelized_instance_norm(self.G, padding=padding)
+    def use_kernelized_instance_norm_for_whole_model(self):
+        use_kernelized_instance_norm(self.G)
 
     def not_use_kernelized_instance_norm_for_whole_model(self):
         not_use_kernelized_instance_norm(self.G)

--- a/models/cyclegan.py
+++ b/models/cyclegan.py
@@ -49,6 +49,7 @@ class CycleGanModel(BaseModel):
         ]
 
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         # Discrimnator would not be used during inference,
         # so specification of instane normalization is not required
         self.G_X2Y = Generator(norm_cfg=norm_cfg).to(self.device)

--- a/models/cyclegan.py
+++ b/models/cyclegan.py
@@ -122,13 +122,13 @@ class CycleGanModel(BaseModel):
             Y_fake = self.forward(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
+    def inference_with_anchor(self, X, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G_X2Y.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                X, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         return Y_fake
 
@@ -257,19 +257,15 @@ class CycleGanModel(BaseModel):
         self,
         y_anchor_num,
         x_anchor_num,
-        kernel_padding=1,
-        kernel_mode="constant",
     ):
         init_kernelized_instance_norm(
             self.G_X2Y,
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
-            kernel_padding=kernel_padding,
-            kernel_mode=kernel_mode,
         )
 
-    def use_kernelized_instance_norm_for_whole_model(self, padding=1):
-        use_kernelized_instance_norm(self.G_X2Y, padding=padding)
+    def use_kernelized_instance_norm_for_whole_model(self):
+        use_kernelized_instance_norm(self.G_X2Y)
 
     def not_use_kernelized_instance_norm_for_whole_model(self):
         not_use_kernelized_instance_norm(self.G_X2Y)

--- a/models/discriminator.py
+++ b/models/discriminator.py
@@ -13,11 +13,12 @@ class DiscriminatorBasicBlock(nn.Module):
         out_features,
         do_downsample=True,
         do_instancenorm=True,
-        norm_cfg=None
+        norm_cfg=None,
     ):
         super().__init__()
 
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         self.do_downsample = do_downsample
         self.do_instancenorm = do_instancenorm
 

--- a/models/generator.py
+++ b/models/generator.py
@@ -23,16 +23,16 @@ class ResnetBlock(nn.Module):
     def forward(self, x):
         return x + self.model(x)
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         x_residual = x
         x = self.model[:2](x)
         x = self.model[2](
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.model[3:6](x)
         x = self.model[6](
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         return x_residual + x
 
@@ -90,13 +90,13 @@ class GeneratorBasicBlock(nn.Module):
             x = self.downsample(x)
         return x_hook, x
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         if self.do_upsample:
             x = self.upsample(x)
         x = self.conv(x)
         x = self.instancenorm(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.relu(x)
         if self.do_downsample:
@@ -221,29 +221,29 @@ class Generator(nn.Module):
         x = self.block7(x)
         return x, feature_maps
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor, padding):
+    def forward_with_anchor(self, x, y_anchor, x_anchor):
         assert self.norm_cfg['type'] == "kin"
         x = self.reflectionpad(x)
         x = self.block1[0](x)
         x = self.block1[1](
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor
         )
         x = self.block1[2](x)
         x = self.downsampleblock2.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.downsampleblock3.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         for resnetblock in self.resnetblocks4:
             x = resnetblock.forward_with_anchor(
-                x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                x, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         x = self.upsampleblock5.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.upsampleblock6.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+            x, y_anchor=y_anchor, x_anchor=x_anchor,
         )
         x = self.block7(x)
         return x

--- a/models/generator.py
+++ b/models/generator.py
@@ -10,6 +10,7 @@ class ResnetBlock(nn.Module):
     def __init__(self, features, norm_cfg=None):
         super().__init__()
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
         self.model = nn.Sequential(
             nn.ReflectionPad2d(1),
             nn.Conv2d(features, features, kernel_size=3),
@@ -59,6 +60,7 @@ class GeneratorBasicBlock(nn.Module):
         self.do_upsample = do_upsample
         self.do_downsample = do_downsample
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         if self.do_upsample:
             self.upsample = Upsample(in_features)
@@ -121,6 +123,7 @@ class Generator(nn.Module):
         super().__init__()
         self.residuals = residuals
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         self.reflectionpad = nn.ReflectionPad2d(3)
         self.block1 = nn.Sequential(

--- a/models/kin.py
+++ b/models/kin.py
@@ -6,8 +6,22 @@ from utils.util import get_kernel
 
 class KernelizedInstanceNorm(nn.Module):
 
-    def __init__(self, num_features, eps=0, affine=True, device="cuda"):
+    def __init__(
+        self,
+        num_features,
+        kernel_size=3,
+        kernel_type='gaussian',
+        padding=1,
+        eps=0,
+        affine=True,
+        device="cuda",
+    ):
         super(KernelizedInstanceNorm, self).__init__()
+
+        if kernel_size % 2 == 0:
+            raise ValueError(
+                f'kernel_size must be an odd number. But got {kernel_size}.',
+            )
 
         # if use normal instance normalization during evaluation mode
         self.normal_instance_normalization = False
@@ -17,8 +31,16 @@ class KernelizedInstanceNorm(nn.Module):
         self.collection_mode = False
 
         self.num_features = num_features
+        self.kernel_size = kernel_size
+        self.kernel_type = kernel_type
+        self.padding = padding
         self.eps = eps
         self.device = device
+
+        self.kernel = get_kernel(
+            padding=(self.kernel_size - 1) // 2,
+            mode=self.kernel_type,
+        ).to(self.device)
 
         if affine:
             self.weight = nn.Parameter(
@@ -43,17 +65,11 @@ class KernelizedInstanceNorm(nn.Module):
             self.device
         )
 
-    def init_kernel(self, kernel_padding, kernel_mode):
-        # TODO: 1. Consider to use strategy pattern
-        # TODO: 2. padding => kernel_size, and raise an error for even number
-        kernel = get_kernel(padding=kernel_padding, mode=kernel_mode)
-        self.kernel = kernel.to(self.device)
-
-    def pad_table(self, padding):
+    def pad_table(self):
         # modify
         # padded table shape inconsisency
         # TODO: Don't permute the dimensions
-        pad_func = nn.ReplicationPad2d((padding, padding, padding, padding))
+        pad_func = nn.ReplicationPad2d((self.padding, self.padding, self.padding, self.padding))
         self.padded_mean_table = pad_func(
             self.mean_table.permute(2, 0, 1).unsqueeze(0)
         )  # [H, W, C] -> [C, H, W] -> [N, C, H, W]
@@ -67,7 +83,7 @@ class KernelizedInstanceNorm(nn.Module):
         x = (x - x_mean) / x_std  # * self.weight + self.bias
         return x
 
-    def forward(self, x, y_anchor=None, x_anchor=None, padding=1):
+    def forward(self, x, y_anchor=None, x_anchor=None):
         # TODO: Do not reply on self.training
         if self.training or self.normal_instance_normalization:
             return self.forward_normal(x)
@@ -99,9 +115,9 @@ class KernelizedInstanceNorm(nn.Module):
                 assert x.shape[0] == 1
 
                 top = y_anchor
-                down = y_anchor + 2 * padding + 1
+                down = y_anchor + 2 * self.padding + 1
                 left = x_anchor
-                right = x_anchor + 2 * padding + 1
+                right = x_anchor + 2 * self.padding + 1
                 x_mean = self.padded_mean_table[
                     :, :, top:down, left:right
                 ]  # 1, C, H, W
@@ -122,9 +138,7 @@ def not_use_kernelized_instance_norm(model):
             layer.normal_instance_normalization = True
 
 
-def init_kernelized_instance_norm(
-    model, y_anchor_num, x_anchor_num, kernel_padding, kernel_mode
-):
+def init_kernelized_instance_norm(model, y_anchor_num, x_anchor_num):
     for _, layer in model.named_modules():
         if isinstance(layer, KernelizedInstanceNorm):
             layer.collection_mode = True
@@ -132,14 +146,11 @@ def init_kernelized_instance_norm(
             layer.init_collection(
                 y_anchor_num=y_anchor_num, x_anchor_num=x_anchor_num
             )
-            layer.init_kernel(
-                kernel_padding=kernel_padding, kernel_mode=kernel_mode
-            )
 
 
-def use_kernelized_instance_norm(model, padding=1):
+def use_kernelized_instance_norm(model):
     for _, layer in model.named_modules():
         if isinstance(layer, KernelizedInstanceNorm):
-            layer.pad_table(padding=padding)
+            layer.pad_table()
             layer.collection_mode = False
             layer.normal_instance_normalization = False

--- a/models/kin.py
+++ b/models/kin.py
@@ -11,7 +11,7 @@ class KernelizedInstanceNorm(nn.Module):
         num_features (int): The number of input features.
         kernel_size (int): The size of kernel used to kernelize.
         kernel_type (str): The kernel type. It must be either 'constant' or 'gaussian'.
-        padding (int): The padding size of cache table.
+        padding (int): The padding size of cache table. It must be `(kernel_size - 1) / 2`.
         eps (float): A value added to the denominator for numerical stability.
         affine (bool): A boolean value that when set to True, this module has learnable
             affine parameters, initialized the same way as done for batch normalization.
@@ -33,6 +33,11 @@ class KernelizedInstanceNorm(nn.Module):
         if kernel_size % 2 == 0:
             raise ValueError(
                 f'kernel_size must be an odd number. But got {kernel_size}.',
+            )
+
+        if padding != (kernel_size - 1) // 2:
+            raise ValueError(
+                f'padding must be (kernel_size - 1) / 2. But got {padding}.'
             )
 
         # if use normal instance normalization during evaluation mode

--- a/models/kin.py
+++ b/models/kin.py
@@ -5,6 +5,18 @@ from utils.util import get_kernel
 
 
 class KernelizedInstanceNorm(nn.Module):
+    """
+
+    Attributes:
+        num_features (int): The number of input features.
+        kernel_size (int): The size of kernel used to kernelize.
+        kernel_type (str): The kernel type. It must be either 'constant' or 'gaussian'.
+        padding (int): The padding size of cache table.
+        eps (float): A value added to the denominator for numerical stability.
+        affine (bool): A boolean value that when set to True, this module has learnable
+            affine parameters, initialized the same way as done for batch normalization.
+        device (str): The device to place the variables.
+    """
 
     def __init__(
         self,
@@ -35,6 +47,7 @@ class KernelizedInstanceNorm(nn.Module):
         self.kernel_type = kernel_type
         self.padding = padding
         self.eps = eps
+        self.affine = affine
         self.device = device
 
         self.kernel = get_kernel(
@@ -42,7 +55,7 @@ class KernelizedInstanceNorm(nn.Module):
             mode=self.kernel_type,
         ).to(self.device)
 
-        if affine:
+        if self.affine:
             self.weight = nn.Parameter(
                 torch.ones(size=(1, num_features, 1, 1), requires_grad=True)
             ).to(device)

--- a/models/lsesim.py
+++ b/models/lsesim.py
@@ -60,6 +60,7 @@ class LSeSim(BaseModel):
         self.model_names = ["G", "D"] if self.isTrain else ["G"]
 
         self.norm_cfg = norm_cfg or {'type': 'in'}
+        self.norm_cfg = {k.lower(): v for k, v in self.norm_cfg.items()}
 
         ###########################################################
         self.G = Generator(norm_cfg=self.norm_cfg).to(self.device)

--- a/models/lsesim.py
+++ b/models/lsesim.py
@@ -33,7 +33,7 @@ from models.tin import (
 class LSeSim(BaseModel):
     # instance normalization can be different from
     # the one specified during training
-    def __init__(self, config, normalization="in", isTrain=True):
+    def __init__(self, config, norm_cfg=None, isTrain=True):
         BaseModel.__init__(self, config)
         self.isTrain = isTrain
         self.attn_layers = "4, 7, 9"
@@ -59,10 +59,10 @@ class LSeSim(BaseModel):
         # specify the models you want to save to the disk
         self.model_names = ["G", "D"] if self.isTrain else ["G"]
 
-        self.normalization = normalization
+        self.norm_cfg = norm_cfg or {'type': 'in'}
 
         ###########################################################
-        self.G = Generator(normalization=normalization).to(self.device)
+        self.G = Generator(norm_cfg=self.norm_cfg).to(self.device)
 
         if self.isTrain:
             self.D = Discriminator().to(self.device)
@@ -381,13 +381,13 @@ class LSeSim(BaseModel):
             Y_fake = self.G(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor, padding):
-        assert self.normalization == "kin"
+    def inference_with_anchor(self, X, y_anchor, x_anchor):
+        assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor, padding=padding
+                X, y_anchor=y_anchor, x_anchor=x_anchor,
             )
         return Y_fake
 
@@ -405,17 +405,16 @@ class LSeSim(BaseModel):
         not_use_thumbnail_instance_norm(self.G)
 
     def init_kernelized_instance_norm_for_whole_model(
-        self, y_anchor_num, x_anchor_num, kernel=(torch.ones(1, 1, 3, 3) / 9)
+        self, y_anchor_num, x_anchor_num
     ):
         init_kernelized_instance_norm(
             self.G,
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
-            kernel=kernel,
         )
 
-    def use_kernelized_instance_norm_for_whole_model(self, padding=1):
-        use_kernelized_instance_norm(self.G, padding=padding)
+    def use_kernelized_instance_norm_for_whole_model(self):
+        use_kernelized_instance_norm(self.G)
 
     def not_use_kernelized_instance_norm_for_whole_model(self):
         not_use_kernelized_instance_norm(self.G)

--- a/models/tests/test_cut.py
+++ b/models/tests/test_cut.py
@@ -42,7 +42,7 @@ def kin_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        norm_cfg={'type': 'kin'},
+        norm_cfg=config["INFERENCE_SETTING"]["NORMALIZATION"],
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
@@ -100,8 +100,8 @@ def kin_expected_outputs(config):
         config["EXPERIMENT_NAME"],
         "kin",
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
-        f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_"
-        f"{config['INFERENCE_SETTING']['KIN_PADDING']}"
+        f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_"
+        f"{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}"
     )
     expected_output_files = sorted(
         os.listdir(expected_output_dir)
@@ -153,8 +153,6 @@ def test_inference_with_anchor(
     kin_model.init_kernelized_instance_norm_for_whole_model(
         y_anchor_num=y_anchor_num + 1,
         x_anchor_num=x_anchor_num + 1,
-        kernel_padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
-        kernel_mode=config["INFERENCE_SETTING"]["KIN_KERNEL"],
     )
 
     for idx, data in enumerate(dataloader):
@@ -168,12 +166,9 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
         )
 
-    kin_model.use_kernelized_instance_norm_for_whole_model(
-        padding=config["INFERENCE_SETTING"]["KIN_PADDING"]
-    )
+    kin_model.use_kernelized_instance_norm_for_whole_model()
 
     for idx, data in enumerate(dataloader):
         X, _, y_anchor, x_anchor = (
@@ -186,7 +181,6 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
         )
         test_output_tensor = reverse_image_normalize(Y_fake)
 

--- a/models/tests/test_cyclegan.py
+++ b/models/tests/test_cyclegan.py
@@ -42,7 +42,7 @@ def kin_model(config):
     model = get_model(
         config=config,
         model_name=config["MODEL_NAME"],
-        norm_cfg={'type': 'kin'},
+        norm_cfg=config['INFERENCE_SETTING']['NORMALIZATION'],
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
@@ -100,8 +100,8 @@ def kin_expected_outputs(config):
         config["EXPERIMENT_NAME"],
         "kin",
         config["INFERENCE_SETTING"]["MODEL_VERSION"],
-        f"{config['INFERENCE_SETTING']['KIN_KERNEL']}_"
-        f"{config['INFERENCE_SETTING']['KIN_PADDING']}",
+        f"{config['INFERENCE_SETTING']['NORMALIZATION']['KERNEL_TYPE']}_"
+        f"{config['INFERENCE_SETTING']['NORMALIZATION']['PADDING']}",
 
     )
     expected_output_files = sorted(
@@ -154,8 +154,6 @@ def test_inference_with_anchor(
     kin_model.init_kernelized_instance_norm_for_whole_model(
         y_anchor_num=y_anchor_num + 1,
         x_anchor_num=x_anchor_num + 1,
-        kernel_padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
-        kernel_mode=config["INFERENCE_SETTING"]["KIN_KERNEL"],
     )
 
     for idx, data in enumerate(dataloader):
@@ -169,12 +167,9 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
         )
 
-    kin_model.use_kernelized_instance_norm_for_whole_model(
-        padding=config["INFERENCE_SETTING"]["KIN_PADDING"]
-    )
+    kin_model.use_kernelized_instance_norm_for_whole_model()
 
     for idx, data in enumerate(dataloader):
         X, _, y_anchor, x_anchor = (
@@ -187,7 +182,6 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
-            padding=config["INFERENCE_SETTING"]["KIN_PADDING"],
         )
         test_output_tensor = reverse_image_normalize(Y_fake)
 

--- a/models/tests/test_data/configs/config_lung_lesion_for_test_cut.yaml
+++ b/models/tests/test_data/configs/config_lung_lesion_for_test_cut.yaml
@@ -21,7 +21,9 @@ INFERENCE_SETTING:
   TEST_DIR_Y: "./test_data/test_dir_y/lung_lesion"
   MODEL_VERSION: "latest"
   SAVE_ORIGINAL_IMAGE: False
-  NORMALIZATION: "kin"
+  NORMALIZATION:
+    TYPE: "kin"
+    PADDING: 1
+    KERNEL_TYPE: 'gaussian'
+    KERNEL_SIZE: 3
   THUMBNAIL: "None" # set to "None" if it's not required
-  KIN_PADDING: 1 # for kin
-  KIN_KERNEL: "gaussian" #constant or gaussian

--- a/models/tests/test_data/configs/config_lung_lesion_for_test_cyclegan.yaml
+++ b/models/tests/test_data/configs/config_lung_lesion_for_test_cyclegan.yaml
@@ -21,7 +21,9 @@ INFERENCE_SETTING:
   TEST_DIR_Y: "./test_data/test_dir_y/lung_lesion"
   MODEL_VERSION: "60"
   SAVE_ORIGINAL_IMAGE: False
-  NORMALIZATION: "kin"
+  NORMALIZATION:
+    TYPE: "kin"
+    PADDING: 1
+    KERNEL_SIZE: 3
+    KERNEL_TYPE: 'gaussian'
   THUMBNAIL: "None" # set to "None" if it's not required
-  KIN_PADDING: 1 # for kin
-  KIN_KERNEL: "gaussian" #constant or gaussian


### PR DESCRIPTION
1. Add `kernel_size`, `kernel_type`, and `padding` as init arguments of KIN.
   - kernel_size: The size of kernel used to kernelize.
   - kernel_type: The type of kernel. 'constant' or 'gaussian'.
   - padding: The padding size of cache table.
2. Move `KIN_PADDING` and `KIN_KERNEL` into `NORMALIZATION` and rename to `PADDING` and `KERNEL_TYPE`.
3. Fix norm_cfg error.