### PR TITLE
Use an enum to switch different mode in kin

### DIFF
--- a/F-LSeSim/inference.py
+++ b/F-LSeSim/inference.py
@@ -15,6 +15,7 @@ from yaml.loader import SafeLoader
 from data import create_dataset
 from data.dataset import XInferenceDataset, test_transforms
 from models import create_model
+from models.kin import KernelizedInstanceNorm
 from options.train_options import TrainOptions
 
 
@@ -147,9 +148,9 @@ if __name__ == "__main__":
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
+                mode=KernelizedInstanceNorm.Mode.PHASE_CACHING,
             )
 
-        model.use_kernelized_instance_norm_for_whole_model()
         for idx, data in enumerate(test_loader):
             print(f"Processing {idx}", end="\r")
             X, X_path, y_anchor, x_anchor = (
@@ -162,6 +163,7 @@ if __name__ == "__main__":
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
+                mode=KernelizedInstanceNorm.Mode.PHASE_INFERENCE,
             )
             if config["INFERENCE_SETTING"]["SAVE_ORIGINAL_IMAGE"]:
                 save_image(

--- a/F-LSeSim/models/generator.py
+++ b/F-LSeSim/models/generator.py
@@ -24,13 +24,13 @@ class ResnetBlock(nn.Module):
     def forward(self, x):
         return x + self.model(x)
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         x_residual = x
         x = self.model[:2](x)
-        x = self.model[2](x, y_anchor=y_anchor, x_anchor=x_anchor)
+        x = self.model[2](x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode)
         x = self.model[3:6](x)
-        x = self.model[6](x, y_anchor=y_anchor, x_anchor=x_anchor)
+        x = self.model[6](x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode)
         return x_residual + x
 
     def analyze_feature_map(self, x):
@@ -88,12 +88,12 @@ class GeneratorBasicBlock(nn.Module):
             x = self.downsample(x)
         return x_hook, x
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         if self.do_upsample:
             x = self.upsample(x)
         x = self.conv(x)
-        x = self.instancenorm(x, y_anchor=y_anchor, x_anchor=x_anchor)
+        x = self.instancenorm(x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode)
         x = self.relu(x)
         if self.do_downsample:
             x = self.downsample(x)
@@ -215,27 +215,27 @@ class Generator(nn.Module):
         x = self.block7(x)
         return x, feature_maps
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         x = self.reflectionpad(x)
         x = self.block1[0](x)
-        x = self.block1[1](x, y_anchor=y_anchor, x_anchor=x_anchor)
+        x = self.block1[1](x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode)
         x = self.block1[2](x)
         x = self.downsampleblock2.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.downsampleblock3.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         for resnetblock in self.resnetblocks4:
             x = resnetblock.forward_with_anchor(
-                x, y_anchor=y_anchor, x_anchor=x_anchor,
+                x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         x = self.upsampleblock5.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.upsampleblock6.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.block7(x)
         return x

--- a/F-LSeSim/models/kin.py
+++ b/F-LSeSim/models/kin.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from functools import cached_property
 
 import torch
@@ -7,6 +8,11 @@ from utils.util import get_kernel
 
 
 class KernelizedInstanceNorm(nn.Module):
+
+    class Mode(IntEnum):
+        PHASE_CACHING = 1
+        PHASE_INFERENCE = 2
+
     """
 
     Attributes:
@@ -41,13 +47,6 @@ class KernelizedInstanceNorm(nn.Module):
             raise ValueError(
                 f'padding must be (kernel_size - 1) / 2. But got {padding}.'
             )
-
-        # if use normal instance normalization during evaluation mode
-        self.normal_instance_normalization = False
-
-        # if collecting instance normalization mean and std
-        # during evaluation mode'
-        self.collection_mode = False
 
         self.num_features = num_features
         self.kernel_size = kernel_size
@@ -113,16 +112,12 @@ class KernelizedInstanceNorm(nn.Module):
         x = (x - x_mean) / x_std  # * self.weight + self.bias
         return x
 
-    def forward(self, x, y_anchor=None, x_anchor=None):
-        # TODO: Do not rely on self.training
-        if self.training or self.normal_instance_normalization:
+    def forward(self, x, y_anchor=None, x_anchor=None, mode=1):
+        if self.training or x_anchor is None or y_anchor is None:
             return self.forward_normal(x)
 
         else:
-            assert y_anchor is not None
-            assert x_anchor is not None
-
-            if self.collection_mode:
+            if mode == self.Mode.PHASE_CACHING:
                 x_var, x_mean = torch.var_mean(x, dim=(2, 3))  # [B, C]
                 x_std = torch.sqrt(x_var + self.eps)
                 # x_anchor, y_anchor = [B], [B]
@@ -133,7 +128,7 @@ class KernelizedInstanceNorm(nn.Module):
                 x_mean = x_mean.unsqueeze(-1).unsqueeze(-1)
                 x_std = x_std.unsqueeze(-1).unsqueeze(-1)
 
-            else:
+            elif mode == self.Mode.PHASE_INFERENCE:
 
                 def multiply_kernel(x):
                     x = x * self.kernel  # [1, C, H, W] * [H, W] = [1, C, H, W]
@@ -157,29 +152,16 @@ class KernelizedInstanceNorm(nn.Module):
                 x_mean = multiply_kernel(x_mean)
                 x_std = multiply_kernel(x_std)
 
+            else:
+                raise ValueError(f'Unknown mode: {mode}.')
+
             x = (x - x_mean) / x_std * self.weight + self.bias
             return x
-
-
-def not_use_kernelized_instance_norm(model):
-    for _, layer in model.named_modules():
-        if isinstance(layer, KernelizedInstanceNorm):
-            layer.collection_mode = False
-            layer.normal_instance_normalization = True
 
 
 def init_kernelized_instance_norm(model, y_anchor_num, x_anchor_num):
     for _, layer in model.named_modules():
         if isinstance(layer, KernelizedInstanceNorm):
-            layer.collection_mode = True
-            layer.normal_instance_normalization = False
             layer.init_collection(
                 y_anchor_num=y_anchor_num, x_anchor_num=x_anchor_num
             )
-
-
-def use_kernelized_instance_norm(model):
-    for _, layer in model.named_modules():
-        if isinstance(layer, KernelizedInstanceNorm):
-            layer.collection_mode = False
-            layer.normal_instance_normalization = False

--- a/F-LSeSim/models/sc_model.py
+++ b/F-LSeSim/models/sc_model.py
@@ -4,8 +4,6 @@ import torch
 
 from models.kin import (
     init_kernelized_instance_norm,
-    not_use_kernelized_instance_norm,
-    use_kernelized_instance_norm,
 )
 from models.tin import (
     init_thumbnail_instance_norm,
@@ -278,13 +276,13 @@ class SCModel(BaseModel):
             Y_fake, _ = self.netG(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor):
+    def inference_with_anchor(self, X, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.netG.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor,
+                X, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         return Y_fake
 
@@ -454,9 +452,3 @@ class SCModel(BaseModel):
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
         )
-
-    def use_kernelized_instance_norm_for_whole_model(self):
-        use_kernelized_instance_norm(self.netG)
-
-    def not_use_kernelized_instance_norm_for_whole_model(self):
-        not_use_kernelized_instance_norm(self.netG)

--- a/inference.py
+++ b/inference.py
@@ -6,6 +6,7 @@ from torch.utils.data import DataLoader
 from torchvision.utils import save_image
 
 from models.model import get_model
+from models.kin import KernelizedInstanceNorm
 from utils.dataset import XInferenceDataset
 from utils.util import (
     read_yaml_config,
@@ -131,9 +132,9 @@ def main():
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
+                mode=KernelizedInstanceNorm.Mode.PHASE_CACHING,
             )
 
-        model.use_kernelized_instance_norm_for_whole_model()
         for idx, data in enumerate(test_loader):
             print(f"Processing {idx}", end="\r")
             X, X_path, y_anchor, x_anchor = (
@@ -146,6 +147,7 @@ def main():
                 X,
                 y_anchor=y_anchor,
                 x_anchor=x_anchor,
+                mode=KernelizedInstanceNorm.Mode.PHASE_INFERENCE,
             )
             if config["INFERENCE_SETTING"]["SAVE_ORIGINAL_IMAGE"]:
                 save_image(

--- a/models/base.py
+++ b/models/base.py
@@ -111,14 +111,6 @@ class BaseModel(ABC):
     def init_kernelized_instance_norm_for_whole_model(self):
         pass
 
-    @abstractmethod
-    def use_kernelized_instance_norm_for_whole_model(self):
-        pass
-
-    @abstractmethod
-    def not_use_kernelized_instance_norm_for_whole_model(self):
-        pass
-
     def train(self):
         """Make models eval mode during test time"""
         for name in self.model_names:

--- a/models/cut.py
+++ b/models/cut.py
@@ -8,8 +8,6 @@ from models.discriminator import Discriminator
 from models.generator import Generator
 from models.kin import (
     init_kernelized_instance_norm,
-    not_use_kernelized_instance_norm,
-    use_kernelized_instance_norm,
 )
 from models.projector import Head
 from models.tin import (
@@ -101,13 +99,13 @@ class ContrastiveModel(BaseModel):
             Y_fake = self.G(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor):
+    def inference_with_anchor(self, X, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor,
+                X, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         return Y_fake
 
@@ -204,9 +202,3 @@ class ContrastiveModel(BaseModel):
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
         )
-
-    def use_kernelized_instance_norm_for_whole_model(self):
-        use_kernelized_instance_norm(self.G)
-
-    def not_use_kernelized_instance_norm_for_whole_model(self):
-        not_use_kernelized_instance_norm(self.G)

--- a/models/cyclegan.py
+++ b/models/cyclegan.py
@@ -11,8 +11,6 @@ from models.discriminator import Discriminator
 from models.generator import Generator
 from models.kin import (
     init_kernelized_instance_norm,
-    not_use_kernelized_instance_norm,
-    use_kernelized_instance_norm,
 )
 from models.tin import (
     init_thumbnail_instance_norm,
@@ -123,13 +121,14 @@ class CycleGanModel(BaseModel):
             Y_fake = self.forward(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor):
+    def inference_with_anchor(self, X, y_anchor, x_anchor, mode):
+        # TODO: check its type instead of norm_cfg['type']
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G_X2Y.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor,
+                X, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         return Y_fake
 
@@ -264,9 +263,3 @@ class CycleGanModel(BaseModel):
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
         )
-
-    def use_kernelized_instance_norm_for_whole_model(self):
-        use_kernelized_instance_norm(self.G_X2Y)
-
-    def not_use_kernelized_instance_norm_for_whole_model(self):
-        not_use_kernelized_instance_norm(self.G_X2Y)

--- a/models/generator.py
+++ b/models/generator.py
@@ -24,16 +24,16 @@ class ResnetBlock(nn.Module):
     def forward(self, x):
         return x + self.model(x)
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         x_residual = x
         x = self.model[:2](x)
         x = self.model[2](
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.model[3:6](x)
         x = self.model[6](
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         return x_residual + x
 
@@ -92,13 +92,16 @@ class GeneratorBasicBlock(nn.Module):
             x = self.downsample(x)
         return x_hook, x
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         if self.do_upsample:
             x = self.upsample(x)
         x = self.conv(x)
         x = self.instancenorm(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x,
+            y_anchor=y_anchor,
+            x_anchor=x_anchor,
+            mode=mode,
         )
         x = self.relu(x)
         if self.do_downsample:
@@ -224,29 +227,29 @@ class Generator(nn.Module):
         x = self.block7(x)
         return x, feature_maps
 
-    def forward_with_anchor(self, x, y_anchor, x_anchor):
+    def forward_with_anchor(self, x, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         x = self.reflectionpad(x)
         x = self.block1[0](x)
         x = self.block1[1](
-            x, y_anchor=y_anchor, x_anchor=x_anchor
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.block1[2](x)
         x = self.downsampleblock2.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.downsampleblock3.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         for resnetblock in self.resnetblocks4:
             x = resnetblock.forward_with_anchor(
-                x, y_anchor=y_anchor, x_anchor=x_anchor,
+                x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         x = self.upsampleblock5.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.upsampleblock6.forward_with_anchor(
-            x, y_anchor=y_anchor, x_anchor=x_anchor,
+            x, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
         )
         x = self.block7(x)
         return x

--- a/models/kin.py
+++ b/models/kin.py
@@ -117,9 +117,6 @@ class KernelizedInstanceNorm(nn.Module):
             return self.forward_normal(x)
 
         else:
-            assert y_anchor is not None
-            assert x_anchor is not None
-
             if mode == self.Mode.PHASE_CACHING:
                 x_var, x_mean = torch.var_mean(x, dim=(2, 3))  # [B, C]
                 x_std = torch.sqrt(x_var + self.eps)

--- a/models/lsesim.py
+++ b/models/lsesim.py
@@ -11,8 +11,6 @@ from models.discriminator import Discriminator
 from models.generator import Generator
 from models.kin import (
     init_kernelized_instance_norm,
-    not_use_kernelized_instance_norm,
-    use_kernelized_instance_norm,
 )
 from models.lsesim_loss import (
     VGG16,
@@ -382,13 +380,13 @@ class LSeSim(BaseModel):
             Y_fake = self.G(X)
         return Y_fake
 
-    def inference_with_anchor(self, X, y_anchor, x_anchor):
+    def inference_with_anchor(self, X, y_anchor, x_anchor, mode):
         assert self.norm_cfg['type'] == "kin"
         self.eval()
         with torch.no_grad():
             X = X.to(self.device)
             Y_fake = self.G.forward_with_anchor(
-                X, y_anchor=y_anchor, x_anchor=x_anchor,
+                X, y_anchor=y_anchor, x_anchor=x_anchor, mode=mode,
             )
         return Y_fake
 
@@ -413,9 +411,3 @@ class LSeSim(BaseModel):
             y_anchor_num=y_anchor_num,
             x_anchor_num=x_anchor_num,
         )
-
-    def use_kernelized_instance_norm_for_whole_model(self):
-        use_kernelized_instance_norm(self.G)
-
-    def not_use_kernelized_instance_norm_for_whole_model(self):
-        not_use_kernelized_instance_norm(self.G)

--- a/models/tests/test_cut.py
+++ b/models/tests/test_cut.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 from models.model import get_model
+from models.kin import KernelizedInstanceNorm
 from PIL import Image
 from torch.utils.data import DataLoader
 from torchvision.utils import make_grid
@@ -46,6 +47,7 @@ def kin_model(config):
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
+    model.eval()
 
     return model
 
@@ -166,9 +168,8 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
+            mode=KernelizedInstanceNorm.Mode.PHASE_CACHING,
         )
-
-    kin_model.use_kernelized_instance_norm_for_whole_model()
 
     for idx, data in enumerate(dataloader):
         X, _, y_anchor, x_anchor = (
@@ -181,6 +182,7 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
+            mode=KernelizedInstanceNorm.Mode.PHASE_INFERENCE,
         )
         test_output_tensor = reverse_image_normalize(Y_fake)
 

--- a/models/tests/test_cyclegan.py
+++ b/models/tests/test_cyclegan.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 from models.model import get_model
+from models.kin import KernelizedInstanceNorm
 from PIL import Image
 from torch.utils.data import DataLoader
 from torchvision.utils import make_grid
@@ -46,6 +47,7 @@ def kin_model(config):
         isTrain=False,
     )
     model.load_networks(config["INFERENCE_SETTING"]["MODEL_VERSION"])
+    model.eval()
 
     return model
 
@@ -167,9 +169,8 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
+            mode=KernelizedInstanceNorm.Mode.PHASE_CACHING,
         )
-
-    kin_model.use_kernelized_instance_norm_for_whole_model()
 
     for idx, data in enumerate(dataloader):
         X, _, y_anchor, x_anchor = (
@@ -182,6 +183,7 @@ def test_inference_with_anchor(
             X,
             y_anchor=y_anchor,
             x_anchor=x_anchor,
+            mode=KernelizedInstanceNorm.Mode.PHASE_INFERENCE,
         )
         test_output_tensor = reverse_image_normalize(Y_fake)
 

--- a/models/tests/test_kin.py
+++ b/models/tests/test_kin.py
@@ -33,24 +33,19 @@ def test_init_collection():
     np.testing.assert_array_equal(layer.std_table.numpy(), expected_std_table)
 
 
-def test_forward_with_normal_instance_normalization():
+def test_forward_without_anchors():
     layer = KernelizedInstanceNorm(num_features=3, device='cpu')
-    layer.normal_instance_normalization = True
     x = np.random.normal(size=(1, 3, 32, 32)).astype(np.float32)
     x = torch.FloatTensor(x)
-
     expected = normalize(x)
 
-    check = layer.forward_normal(torch.FloatTensor(x))
+    check = layer.forward(torch.FloatTensor(x))
 
     assert check.numpy() == pytest.approx(expected, abs=1e-6)
 
 
-def test_forward_with_collection_mode():
+def test_forward_with_mode_1():
     layer = KernelizedInstanceNorm(num_features=3, kernel_type='constant', device='cpu').eval()
-    layer.collection_mode = True
-    layer.normal_instance_normalization = False
-
     layer.init_collection(y_anchor_num=3, x_anchor_num=3)
 
     x = np.random.normal(size=(1, 3, 32, 32)).astype(np.float32)
@@ -64,28 +59,22 @@ def test_forward_with_collection_mode():
     expected_mean_table[0, 0] = mean
     expected_std_table[0, 0] = std
 
-    check = layer.forward(x, x_anchor=0, y_anchor=0)
+    check = layer.forward(x, x_anchor=0, y_anchor=0, mode=KernelizedInstanceNorm.Mode.PHASE_CACHING)
 
     assert check.detach().numpy() == pytest.approx(normalize(x).numpy(), abs=1e-6)
     assert layer.mean_table.numpy() == pytest.approx(expected_mean_table)
     assert layer.std_table.numpy() == pytest.approx(expected_std_table)
 
 
-def test_forward_with_kernelized():
+def test_forward_with_mode_2():
     layer = KernelizedInstanceNorm(num_features=3, kernel_type='constant', device='cpu').eval()
-    layer.collection_mode = True
-    layer.normal_instance_normalization = False
-
     layer.init_collection(y_anchor_num=3, x_anchor_num=3)
 
     x = np.random.normal(size=(1, 3, 32, 32)).astype(np.float32)
     x = torch.FloatTensor(x)
 
-    layer.forward(x, x_anchor=1, y_anchor=1)
-
-    layer.collection_mode = False
-
-    check = layer.forward(x, x_anchor=1, y_anchor=1)
+    layer.forward(x, x_anchor=1, y_anchor=1, mode=KernelizedInstanceNorm.Mode.PHASE_CACHING)
+    check = layer.forward(x, x_anchor=1, y_anchor=1, mode=KernelizedInstanceNorm.Mode.PHASE_INFERENCE)
     std, mean = torch.std_mean(x, dim=(2, 3), keepdim=True)
 
     mean /= 9


### PR DESCRIPTION
As the discussion in #8, use an enum to switch the mode of KIN. It will switch to normal instance normalization if:
1. Anchors are not provided.
2. It's in training mode.

Other modifications:
1. Remove `use_kernelized_instance_norm` and `not_use_kernelized_instance_norm`. They are no long used.
2. Remove functions related to `use_kernelized_instance_norm` and `not_use_kernelized_instance_norm`.
3. Remove internal state of KIN.